### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ const keys = image.generateKeys();
 const img = fs.readFileSync('image.jpg')
 
 const encryptImage = image.encrypt(img, keys.publicKey, keys.symmetricKey);
+const encryptedData = fs.readFileSync('encrypted.bin');
 
 const decryptedImage = image.decrypt(encryptedData,keys.privateKey);
 


### PR DESCRIPTION
'encryptedData' was not defined in #1 
#Example of encryption and decryption of Image.